### PR TITLE
change class "admin-pages" to admin-{{ target }}

### DIFF
--- a/admin/templates/flex-objects/types/default/edit.html.twig
+++ b/admin/templates/flex-objects/types/default/edit.html.twig
@@ -72,7 +72,7 @@
 
 {% block content %}
     {% if allowed %}
-        <div class="clear directory admin-pages">
+        <div class="clear directory admin-{{ target }}">
             <div class="admin-form-wrapper">
                 <div id="admin-topbar">
                     {% block topbar %}{% endblock %}


### PR DESCRIPTION
The class "admin-pages" is only used for the tabs in the admin pages view. This class adds a margin to the tabs to allow a gap for the `Normal|Expert` mode switcher buttons:

![image](https://i.imgur.com/rOlX6Da.png)

However switching to `admin-{{ target }}` will allow admin-pages to continue working on pages but also fix the tabs for non pages custom flex objects as well adding an extra line of css customization for plugins to target specifically their own objects.

Custom type using tabs with `admin-{{ target }}`

![](https://user-images.githubusercontent.com/7531933/82473618-c30d0f00-9ac1-11ea-8450-e432d9dc23d5.png)

Custom type using tabs with `admin-pages` :

![](https://user-images.githubusercontent.com/7531933/82473733-ee8ff980-9ac1-11ea-957b-de69d1adebb2.png)