### PR TITLE
adding deny option to filepicker

### DIFF
--- a/classes/Controllers/MediaController.php
+++ b/classes/Controllers/MediaController.php
@@ -395,6 +395,16 @@ class MediaController extends AbstractController
             });
         }
 
+        if (isset($settings['deny'])) {
+            $available_files = array_filter($available_files, function ($file) use ($settings) {
+                return $this->filterDeniedFiles($file, $settings);
+            });
+
+            $pending_files = array_filter($pending_files, function ($file) use ($settings) {
+                return $this->filterDeniedFiles($file, $settings);
+            });
+        }
+
         // Generate thumbs if needed
         if (isset($settings['preview_images']) && $settings['preview_images'] === true) {
             foreach ($available_files as $filename) {
@@ -427,6 +437,23 @@ class MediaController extends AbstractController
         foreach ((array)$settings['accept'] as $type) {
             $find = str_replace('*', '.*', $type);
             $valid |= preg_match('#' . $find . '$#i', $file);
+        }
+
+        return $valid;
+    }
+
+    /**
+     * @param string $file
+     * @param array $settings
+     * @return false|int
+     */
+    protected function filterDeniedFiles(string $file, array $settings)
+    {
+        $valid = true;
+
+        foreach ((array)$settings['deny'] as $type) {
+            $find = str_replace('*', '.*', $type);
+            $valid = !preg_match('#' . $find . '$#i', $file);
         }
 
         return $valid;


### PR DESCRIPTION
This option is the reverse of accept.

This is useful to remove the `item.json` from the filepicker without having to set any accepted.

Example:

To create a filepicker that accepts images and videos and files youd need a very large `accept:`, instead you can just have a 

```
deny:
 - .json
```

and allow everything else