### PR TITLE
Security: Fix Broken Access Control Allowing Non-Superusers to Edit Frontmatter

### DIFF
--- a/classes/Admin/AdminController.php
+++ b/classes/Admin/AdminController.php
@@ -857,6 +857,9 @@ class AdminController
             $form = $this->getForm($object);
 
             $callable = function (array $data, array $files, FlexObject $object) use ($form) {
+
+                $originalData = $object->toArray();
+                
                 if (method_exists($object, 'storeOriginal')) {
                     $object->storeOriginal();
                 }
@@ -870,6 +873,14 @@ class AdminController
                     }
                     $object->frontmatter($data['frontmatter']);
                     unset($data['frontmatter']);
+                }
+
+                $newData = $object->toArray();
+                unset($originalData['updated'], $newData['updated']);
+
+                if ($originalData !== $newData && !$this->user->authorize('admin.super')) {
+                    throw new RuntimeException($this->admin::translate('PLUGIN_ADMIN.INSUFFICIENT_PERMISSIONS_FOR_TASK') . ' edit frontmatter.',
+                        403);
                 }
 
                 if (is_callable([$object, 'check'])) {

--- a/classes/Admin/AdminController.php
+++ b/classes/Admin/AdminController.php
@@ -857,9 +857,13 @@ class AdminController
             $form = $this->getForm($object);
 
             $callable = function (array $data, array $files, FlexObject $object) use ($form) {
+                if (!empty($data['frontmatter']) && !$this->user->authorize('admin.super')) {
+                    throw new RuntimeException(
+                        $this->admin::translate('PLUGIN_ADMIN.INSUFFICIENT_PERMISSIONS_FOR_TASK') . ' edit frontmatter.',
+                        403
+                    );
+                }
 
-                $originalData = $object->toArray();
-                
                 if (method_exists($object, 'storeOriginal')) {
                     $object->storeOriginal();
                 }
@@ -867,20 +871,8 @@ class AdminController
 
                 // Support for expert mode.
                 if (str_ends_with($form->getId(), '-raw') && isset($data['frontmatter']) && is_callable([$object, 'frontmatter'])) {
-                    if (!$this->user->authorize('admin.super')) {
-                        throw new RuntimeException($this->admin::translate('PLUGIN_ADMIN.INSUFFICIENT_PERMISSIONS_FOR_TASK') . ' save raw.',
-                        403);
-                    }
                     $object->frontmatter($data['frontmatter']);
                     unset($data['frontmatter']);
-                }
-
-                $newData = $object->toArray();
-                unset($originalData['updated'], $newData['updated']);
-
-                if ($originalData !== $newData && !$this->user->authorize('admin.super')) {
-                    throw new RuntimeException($this->admin::translate('PLUGIN_ADMIN.INSUFFICIENT_PERMISSIONS_FOR_TASK') . ' edit frontmatter.',
-                        403);
                 }
 
                 if (is_callable([$object, 'check'])) {


### PR DESCRIPTION
Due to a weak check of authorization in the `taskSave` method of `AdminController.php`, an editor-level user was able to modify the frontmatter of a form. This allowed them to enable Twig and modify how the form processes form data.

This fix introduces a permission check to ensure that only superusers are allowed to edit the frontmatter field.

An advisory has already been opened regarding this issue :

[https://github.com/getgrav/grav/security/advisories/GHSA-v8x2-fjv7-8hjh](https://github.com/getgrav/grav/security/advisories/GHSA-v8x2-fjv7-8hjh)