### PR TITLE
Add Admin2 Flex list detail metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,68 @@ Simply edit the **Flex Objects** plugin options in the Admin plugin, or copy the
 
 Most interesting configuration option is `directories`, which contains list or blueprint files which will define the flex types.
 
+## Admin Next Nested Detail Rows
+
+Admin Next can render an expandable child Flex table for a parent list row when the parent type exposes `config.admin.list.detail` metadata. This is useful for Flex-to-Flex relations such as users to payments.
+
+Add `config.admin.list.detail` to the parent type blueprint:
+
+```yaml
+config:
+  admin:
+    list:
+      detail:
+        enabled: true
+        label: Payments
+        title: Payments
+        icon: fa-credit-card
+        limit: 12
+        actions: true
+        relation:
+          type: payments
+          local_key: username
+          foreign_key: subject_key
+          sort:
+            paid_at: desc
+```
+
+Options:
+
+- `enabled`: turn detail rows on for the list.
+- `label`: toggle button title and accessibility label.
+- `title`: heading shown above the nested table.
+- `icon`: Font Awesome icon used by the toggle button.
+- `limit`: nested table page size.
+- `actions`: include child edit/delete actions in the nested table.
+- `relation.type`: child Flex type.
+- `relation.local_key`: parent object property used as the relation value.
+- `relation.foreign_key`: child object property filtered by the parent value.
+- `relation.sort`: default child sort order, either `{ by: field, dir: asc|desc }` or `{ field: asc|desc }`.
+
+If `detail.fields` is omitted, the nested table uses the child type list fields. You can also override the nested view in the parent blueprint:
+
+```yaml
+config:
+  admin:
+    list:
+      detail:
+        fields:
+          amount:
+            width: 8
+          status: true
+          paid_at:
+            width: 12
+          internal_notes: false
+```
+
+Field values behave as follows:
+
+- `true`: include the child list field as-is.
+- `false`: hide the field.
+- object: merge local overrides on top of the child list field definition.
+
+The metadata is available through `GET /api/v1/flex-objects/{type}/metadata`, and child rows are loaded through `GET /api/v1/flex-objects/{childType}` with exact `filters[field]=value` query parameters.
+
 ## Security Settings
 
 The plugin includes security settings to protect against unauthorized modification of sensitive page settings:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Options:
 - `title`: heading shown above the nested table.
 - `icon`: Font Awesome icon used by the toggle button.
 - `limit`: nested table page size.
-- `actions`: include child edit/delete actions in the nested table.
+- `actions`: include allowed child edit/delete actions in the nested table.
 - `relation.type`: child Flex type.
 - `relation.local_key`: parent object property used as the relation value.
 - `relation.foreign_key`: child object property filtered by the parent value.
@@ -121,6 +121,8 @@ Field values behave as follows:
 - object: merge local overrides on top of the child list field definition.
 
 The metadata is available through `GET /api/v1/flex-objects/{type}/metadata`, and child rows are loaded through `GET /api/v1/flex-objects/{childType}` with exact `filters[field]=value` query parameters.
+
+Action buttons are permission-aware. When `actions: true`, the API exposes only the actions the current user can perform on the child type (`can_edit`, `can_delete`). Edit also requires the child type to have a generic Admin Next Flex edit route; built-in types with dedicated Admin Next pages do not expose that action through nested detail rows. Exact child filters currently scan the materialized Flex collection in PHP, matching the existing list/search/sort path; very large child directories may eventually need an indexed lookup.
 
 ## Security Settings
 

--- a/classes/Api/FlexApiController.php
+++ b/classes/Api/FlexApiController.php
@@ -6,6 +6,7 @@ namespace Grav\Plugin\FlexObjects\Api;
 
 use Grav\Common\Page\Media;
 use Grav\Framework\Flex\FlexDirectory;
+use Grav\Framework\Flex\Interfaces\FlexCollectionInterface;
 use Grav\Framework\Flex\Interfaces\FlexObjectInterface;
 use Grav\Plugin\Api\Controllers\AbstractApiController;
 use Grav\Plugin\Api\Controllers\HandlesMediaUploads;
@@ -149,50 +150,34 @@ class FlexApiController extends AbstractApiController
                 continue;
             }
 
-            $menu = $config['menu']['list'] ?? [];
-
-            // Resolve the display type (and, for choice fields, the value→label
-            // option map) for each list column so the frontend can render typed
-            // cells — datetimes as dates, selects as labels — instead of raw
-            // stored values. A list column's own `field.type` wins over the
-            // edit-form field type so a list-only `datetime` column isn't
-            // mis-reported as `text`.
-            $listFields = $config['list']['fields'] ?? [];
-            $fieldTypes = [];
-            $fieldOptions = [];
-            try {
-                $formFields = $directory->getBlueprint()->fields();
-                foreach ($listFields as $fieldName => $listFieldCfg) {
-                    $listDef = (array) ($listFieldCfg['field'] ?? []);
-                    $formDef = (array) ($formFields[$fieldName] ?? []);
-
-                    $fieldTypes[$fieldName] = $listDef['type'] ?? $formDef['type'] ?? 'text';
-
-                    $options = $listDef['options'] ?? $formDef['options'] ?? null;
-                    $normalized = $this->normalizeOptionLabels($options);
-                    if ($normalized !== null) {
-                        $fieldOptions[$fieldName] = $normalized;
-                    }
-                }
-            } catch (\Exception $e) {
-                // Non-critical
-            }
-
-            $result[] = [
-                'type'          => $directory->getFlexType(),
-                'title'         => $this->translateLabel($menu['title'] ?? $directory->getTitle()),
-                'description'   => $this->translateLabel($directory->getDescription() ?? ''),
-                'icon'          => $menu['icon'] ?? 'fa-file',
-                'list'          => $this->translateConfigLabels($config['list'] ?? []),
-                'edit'          => $this->translateConfigLabels($config['edit'] ?? []),
-                'search'        => $directory->getConfig('data.search') ?? [],
-                'field_types'   => $fieldTypes,
-                'field_options' => $fieldOptions,
-                'export'        => $this->translateConfigLabels($config['export'] ?? []),
-            ];
+            $result[] = $this->serializeDirectoryMetadata($directory, $user);
         }
 
         return ApiResponse::create($result);
+    }
+
+    /**
+     * GET /flex-objects/{type}/metadata — Get one directory's Admin Next metadata.
+     *
+     * Unlike GET /flex-objects this endpoint also serves built-in directories
+     * such as user-accounts, so dedicated Admin Next pages can opt into the
+     * Flex list/detail configuration without exposing duplicate Flex sidebar
+     * entries.
+     */
+    public function metadata(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requirePermission($request, 'api.access');
+
+        $directory = $this->resolveDirectory($this->getRouteParam($request, 'type'));
+        $user = $this->getUser($request);
+
+        if (!$this->isSuperAdmin($user) && !$directory->isAuthorized('list', 'admin', $user)) {
+            throw new \Grav\Plugin\Api\Exceptions\ForbiddenException('Missing required permission to list this Flex directory.');
+        }
+
+        $this->primeAdminLanguages($request);
+
+        return ApiResponse::create($this->serializeDirectoryMetadata($directory, $user));
     }
 
     /**
@@ -257,6 +242,11 @@ class FlexApiController extends AbstractApiController
         }
 
         $collection = $directory->getCollection();
+        $filters = $this->parseFilters($query['filters'] ?? []);
+
+        if ($filters) {
+            $collection = $this->applyFilters($collection, $filters);
+        }
 
         // Apply search
         if ($search && $search !== '') {
@@ -275,10 +265,11 @@ class FlexApiController extends AbstractApiController
 
         // Get list field names from config
         $listFields = array_keys($directory->getConfig('admin.list.fields') ?? []);
+        $detail = $this->normalizeDetailConfig($directory, $directory->getConfig('admin.list.detail'), $this->getUser($request));
 
         $data = [];
         foreach ($objects as $object) {
-            $data[] = $this->serializeForList($object, $listFields);
+            $data[] = $this->serializeForList($object, $listFields, $detail);
         }
 
         return ApiResponse::paginated(
@@ -724,19 +715,319 @@ class FlexApiController extends AbstractApiController
         return $meta;
     }
 
-    private function serializeForList(FlexObjectInterface $object, array $listFields): array
+    /**
+     * @param mixed $user
+     * @return array<string, mixed>
+     */
+    private function serializeDirectoryMetadata(FlexDirectory $directory, $user): array
+    {
+        $config = $directory->getConfig('admin') ?? [];
+        $menu = $config['menu']['list'] ?? [];
+
+        // Resolve the display type (and, for choice fields, the value→label
+        // option map) for each list column so the frontend can render typed
+        // cells — datetimes as dates, selects as labels — instead of raw
+        // stored values. A list column's own `field.type` wins over the
+        // edit-form field type so a list-only `datetime` column isn't
+        // mis-reported as `text`.
+        $list = $config['list'] ?? [];
+        $listFields = $list['fields'] ?? [];
+        [$fieldTypes, $fieldOptions] = $this->describeListFields($directory, $listFields);
+        $detail = $this->normalizeDetailConfig($directory, $list['detail'] ?? null, $user);
+        if ($detail !== null) {
+            $list['detail'] = $detail;
+        }
+
+        return [
+            'type'          => $directory->getFlexType(),
+            'title'         => $this->translateLabel($menu['title'] ?? $directory->getTitle()),
+            'description'   => $this->translateLabel($directory->getDescription() ?? ''),
+            'icon'          => $menu['icon'] ?? 'fa-file',
+            'list'          => $this->translateConfigLabels($list),
+            'edit'          => $this->translateConfigLabels($config['edit'] ?? []),
+            'search'        => $directory->getConfig('data.search') ?? [],
+            'field_types'   => $fieldTypes,
+            'field_options' => $fieldOptions,
+            'export'        => $this->translateConfigLabels($config['export'] ?? []),
+        ];
+    }
+
+    /**
+     * Resolve field display metadata for Admin Next's Flex list renderer.
+     *
+     * @param array<string, mixed> $listFields
+     * @return array{0: array<string, string>, 1: array<string, array<string, string>>}
+     */
+    private function describeListFields(FlexDirectory $directory, array $listFields): array
+    {
+        $fieldTypes = [];
+        $fieldOptions = [];
+
+        try {
+            $formFields = $directory->getBlueprint()->fields();
+            foreach ($listFields as $fieldName => $listFieldCfg) {
+                $listDef = (array) ($listFieldCfg['field'] ?? []);
+                $formDef = (array) ($formFields[$fieldName] ?? []);
+
+                $fieldTypes[$fieldName] = $listDef['type'] ?? $formDef['type'] ?? 'text';
+
+                $options = $listDef['options'] ?? $formDef['options'] ?? null;
+                $normalized = $this->normalizeOptionLabels($options);
+                if ($normalized !== null) {
+                    $fieldOptions[$fieldName] = $normalized;
+                }
+            }
+        } catch (\Exception $e) {
+            // Non-critical: callers can still render raw values.
+        }
+
+        return [$fieldTypes, $fieldOptions];
+    }
+
+    /**
+     * Normalize config.admin.list.detail into a self-contained Admin Next
+     * contract. The accepted YAML shape mirrors the classic-admin PR:
+     *
+     * detail.fields:
+     * - omitted: use the child type list fields as-is
+     * - true: include the child list field as-is
+     * - false: hide the field
+     * - object: merge overrides on top of the child list field definition
+     *
+     * @param mixed $detail
+     * @param mixed $user
+     * @return array<string, mixed>|null
+     */
+    private function normalizeDetailConfig(FlexDirectory $directory, $detail, $user): ?array
+    {
+        if (!is_array($detail) || empty($detail['enabled'])) {
+            return null;
+        }
+
+        $relation = (array) ($detail['relation'] ?? []);
+        $relatedType = (string) ($relation['type'] ?? '');
+        $localKey = (string) ($relation['local_key'] ?? '');
+        $foreignKey = (string) ($relation['foreign_key'] ?? '');
+        if ($relatedType === '' || $localKey === '' || $foreignKey === '') {
+            return null;
+        }
+
+        $relatedDirectory = $this->getFlex()->getDirectory($relatedType);
+        if (!$relatedDirectory || !$relatedDirectory->isEnabled()) {
+            return null;
+        }
+
+        if (!$this->isSuperAdmin($user) && !$relatedDirectory->isAuthorized('list', 'admin', $user)) {
+            return null;
+        }
+
+        $fields = $this->resolveDetailFields($relatedDirectory, $detail['fields'] ?? null);
+        [$fieldTypes, $fieldOptions] = $this->describeListFields($relatedDirectory, $fields);
+        $relatedOptions = $relatedDirectory->getConfig('admin.list.options') ?? [];
+        $sort = $this->normalizeSortConfig($relation['sort'] ?? ($relatedOptions['order'] ?? []));
+
+        return [
+            'enabled'       => true,
+            'label'         => $detail['label'] ?? $relatedDirectory->getTitle(),
+            'title'         => $detail['title'] ?? ($detail['label'] ?? $relatedDirectory->getTitle()),
+            'icon'          => $detail['icon'] ?? 'fa-list',
+            'limit'         => max(1, (int) ($detail['limit'] ?? ($relatedOptions['per_page'] ?? 10))),
+            'actions'       => (bool) ($detail['actions'] ?? false),
+            'relation'      => [
+                'type'        => $relatedType,
+                'local_key'   => $localKey,
+                'foreign_key' => $foreignKey,
+                'sort'        => $sort,
+            ],
+            'fields'        => $fields,
+            'field_types'   => $fieldTypes,
+            'field_options' => $fieldOptions,
+        ];
+    }
+
+    /**
+     * @param mixed $fields
+     * @return array<string, mixed>
+     */
+    private function resolveDetailFields(FlexDirectory $directory, $fields): array
+    {
+        $defaultFields = $directory->getConfig('admin.list.fields') ?? [];
+
+        if (!is_array($fields) || $fields === []) {
+            return $defaultFields;
+        }
+
+        $resolved = [];
+        foreach ($fields as $key => $options) {
+            if (is_int($key)) {
+                $key = is_string($options) ? $options : null;
+                $options = true;
+            }
+
+            if (!$key || $options === false || $options === null) {
+                continue;
+            }
+
+            $base = (array) ($defaultFields[$key] ?? []);
+            if ($options === true) {
+                $resolved[$key] = $base;
+                continue;
+            }
+
+            if (!is_array($options)) {
+                continue;
+            }
+
+            $resolved[$key] = $base ? array_replace_recursive($base, $options) : $options;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param mixed $sort
+     * @return array{by?: string, dir?: string}
+     */
+    private function normalizeSortConfig($sort): array
+    {
+        if (!is_array($sort)) {
+            return [];
+        }
+
+        if (isset($sort['by'])) {
+            $field = (string) $sort['by'];
+            $dir = strtolower((string) ($sort['dir'] ?? 'asc'));
+
+            return $field !== '' ? ['by' => $field, 'dir' => $dir === 'desc' ? 'desc' : 'asc'] : [];
+        }
+
+        foreach ($sort as $field => $dir) {
+            if (!is_string($field) || $field === '') {
+                continue;
+            }
+            $dir = strtolower((string) $dir);
+
+            return ['by' => $field, 'dir' => $dir === 'desc' ? 'desc' : 'asc'];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param mixed $filters
+     * @return array<string, mixed>
+     */
+    private function parseFilters($filters): array
+    {
+        if (is_string($filters) && $filters !== '') {
+            $decoded = json_decode($filters, true);
+            if (is_array($decoded)) {
+                $filters = $decoded;
+            }
+        }
+
+        if (!is_array($filters)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($filters as $field => $value) {
+            if (!is_string($field) || $field === '' || $value === null || $value === '') {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $values = array_values(array_filter($value, static fn($item) => is_scalar($item) && $item !== ''));
+                if ($values === []) {
+                    continue;
+                }
+                $normalized[$field] = $values;
+                continue;
+            }
+
+            if (is_scalar($value)) {
+                $normalized[$field] = $value;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function applyFilters(FlexCollectionInterface $collection, array $filters): FlexCollectionInterface
+    {
+        return $collection->filter(function (FlexObjectInterface $object) use ($filters): bool {
+            foreach ($filters as $field => $expected) {
+                $actual = $this->getObjectValue($object, $field);
+
+                if (is_array($expected)) {
+                    $expectedValues = array_map('strval', $expected);
+                    if (!in_array((string) $actual, $expectedValues, true)) {
+                        return false;
+                    }
+                    continue;
+                }
+
+                if ((string) $actual !== (string) $expected) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+    }
+
+    private function getObjectValue(FlexObjectInterface $object, string $field): mixed
+    {
+        if ($field === 'key' || $field === 'id') {
+            return $object->getKey();
+        }
+
+        if (method_exists($object, 'getFormValue')) {
+            $value = $object->getFormValue($field);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        if (method_exists($object, 'getNestedProperty')) {
+            $value = $object->getNestedProperty($field);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return $object->getProperty($field);
+    }
+
+    private function serializeForList(FlexObjectInterface $object, array $listFields, ?array $detail = null): array
     {
         $data = ['key' => $object->getKey()];
 
         if ($listFields) {
             foreach ($listFields as $field) {
-                $data[$field] = $object->getProperty($field);
+                $data[$field] = $this->getObjectValue($object, $field);
             }
         } else {
             // No list config — return all data
             $all = $object->jsonSerialize();
             if (is_array($all)) {
                 $data = array_merge($data, $all);
+            }
+        }
+
+        if ($detail) {
+            $localKey = $detail['relation']['local_key'];
+            $localValue = $this->getObjectValue($object, $localKey);
+            if ($localValue !== null && $localValue !== '') {
+                $data['__detail'] = [
+                    'type'    => $detail['relation']['type'],
+                    'title'   => $this->translateLabel((string) $detail['title']),
+                    'label'   => $this->translateLabel((string) $detail['label']),
+                    'filter'  => [$detail['relation']['foreign_key'] => $localValue],
+                    'limit'   => $detail['limit'],
+                    'sort'    => $detail['relation']['sort'],
+                    'actions' => $detail['actions'],
+                ];
             }
         }
 

--- a/classes/Api/FlexApiController.php
+++ b/classes/Api/FlexApiController.php
@@ -32,6 +32,12 @@ class FlexApiController extends AbstractApiController
     private const TRANSLATABLE_LABEL_KEYS = ['label', 'title', 'text', 'help', 'placeholder', 'description'];
 
     /**
+     * Flex types with dedicated Admin Next pages. They can still expose
+     * metadata to those pages, but they do not have the generic Flex edit route.
+     */
+    private const ADMIN_NEXT_DEDICATED_TYPES = ['pages', 'user-accounts', 'user-groups'];
+
+    /**
      * Recursively translate language-key-looking label values within an admin
      * config subtree. {@see translateLabel()} is a no-op for anything that
      * isn't a translation key, so non-label strings pass through unchanged.
@@ -128,15 +134,12 @@ class FlexApiController extends AbstractApiController
         // (matching how the blueprint endpoints translate their labels).
         $this->primeAdminLanguages($request);
 
-        // Skip built-in types that already have dedicated admin-next UI
-        $builtIn = ['pages', 'user-accounts', 'user-groups'];
-
         foreach ($flex->getDirectories() as $directory) {
             if (!$directory->isEnabled()) {
                 continue;
             }
 
-            if (in_array($directory->getFlexType(), $builtIn, true)) {
+            if (in_array($directory->getFlexType(), self::ADMIN_NEXT_DEDICATED_TYPES, true)) {
                 continue;
             }
 
@@ -821,6 +824,14 @@ class FlexApiController extends AbstractApiController
             return null;
         }
 
+        $actionsEnabled = (bool) ($detail['actions'] ?? false);
+        $isSuperAdmin = $this->isSuperAdmin($user);
+        $canEdit = $actionsEnabled
+            && $this->hasAdminNextFlexEditRoute($relatedDirectory)
+            && ($isSuperAdmin || $relatedDirectory->isAuthorized('update', 'admin', $user));
+        $canDelete = $actionsEnabled
+            && ($isSuperAdmin || $relatedDirectory->isAuthorized('delete', 'admin', $user));
+
         $fields = $this->resolveDetailFields($relatedDirectory, $detail['fields'] ?? null);
         [$fieldTypes, $fieldOptions] = $this->describeListFields($relatedDirectory, $fields);
         $relatedOptions = $relatedDirectory->getConfig('admin.list.options') ?? [];
@@ -832,7 +843,9 @@ class FlexApiController extends AbstractApiController
             'title'         => $detail['title'] ?? ($detail['label'] ?? $relatedDirectory->getTitle()),
             'icon'          => $detail['icon'] ?? 'fa-list',
             'limit'         => max(1, (int) ($detail['limit'] ?? ($relatedOptions['per_page'] ?? 10))),
-            'actions'       => (bool) ($detail['actions'] ?? false),
+            'actions'       => $canEdit || $canDelete,
+            'can_edit'      => $canEdit,
+            'can_delete'    => $canDelete,
             'relation'      => [
                 'type'        => $relatedType,
                 'local_key'   => $localKey,
@@ -843,6 +856,17 @@ class FlexApiController extends AbstractApiController
             'field_types'   => $fieldTypes,
             'field_options' => $fieldOptions,
         ];
+    }
+
+    private function hasAdminNextFlexEditRoute(FlexDirectory $directory): bool
+    {
+        if (in_array($directory->getFlexType(), self::ADMIN_NEXT_DEDICATED_TYPES, true)) {
+            return false;
+        }
+
+        $config = $directory->getConfig('admin');
+
+        return is_array($config) && $config !== [] && empty($config['disabled']);
     }
 
     /**
@@ -1005,7 +1029,7 @@ class FlexApiController extends AbstractApiController
 
         if ($listFields) {
             foreach ($listFields as $field) {
-                $data[$field] = $this->getObjectValue($object, $field);
+                $data[$field] = $object->getProperty($field);
             }
         } else {
             // No list config — return all data
@@ -1020,13 +1044,15 @@ class FlexApiController extends AbstractApiController
             $localValue = $this->getObjectValue($object, $localKey);
             if ($localValue !== null && $localValue !== '') {
                 $data['__detail'] = [
-                    'type'    => $detail['relation']['type'],
-                    'title'   => $this->translateLabel((string) $detail['title']),
-                    'label'   => $this->translateLabel((string) $detail['label']),
-                    'filter'  => [$detail['relation']['foreign_key'] => $localValue],
-                    'limit'   => $detail['limit'],
-                    'sort'    => $detail['relation']['sort'],
-                    'actions' => $detail['actions'],
+                    'type'       => $detail['relation']['type'],
+                    'title'      => $this->translateLabel((string) $detail['title']),
+                    'label'      => $this->translateLabel((string) $detail['label']),
+                    'filter'     => [$detail['relation']['foreign_key'] => $localValue],
+                    'limit'      => $detail['limit'],
+                    'sort'       => $detail['relation']['sort'],
+                    'actions'    => $detail['actions'],
+                    'can_edit'   => $detail['can_edit'],
+                    'can_delete' => $detail['can_delete'],
                 ];
             }
         }

--- a/flex-objects.php
+++ b/flex-objects.php
@@ -707,6 +707,7 @@ class FlexObjectsPlugin extends Plugin
         $routes->get('/flex-objects', [$controller, 'directories']);
 
         // CRUD routes — static paths before parameterized (FastRoute constraint)
+        $routes->get('/flex-objects/{type}/metadata', [$controller, 'metadata']);
         $routes->get('/flex-objects/{type}/export', [$controller, 'export']);
         $routes->get('/flex-objects/{type}', [$controller, 'index']);
         $routes->post('/flex-objects/{type}', [$controller, 'create']);

--- a/tests/Unit/Api/FlexApiControllerTranslationTest.php
+++ b/tests/Unit/Api/FlexApiControllerTranslationTest.php
@@ -97,6 +97,22 @@ class FlexApiControllerTranslationTest extends TestCase
         );
     }
 
+    #[Test]
+    public function normalizes_detail_sort_to_admin_next_contract(): void
+    {
+        self::assertSame(
+            ['by' => 'timeline_at', 'dir' => 'desc'],
+            $this->invoke('normalizeSortConfig', ['timeline_at' => 'desc']),
+        );
+
+        self::assertSame(
+            ['by' => 'paid_at', 'dir' => 'asc'],
+            $this->invoke('normalizeSortConfig', ['by' => 'paid_at', 'dir' => 'sideways']),
+        );
+
+        self::assertSame([], $this->invoke('normalizeSortConfig', []));
+    }
+
     private function invoke(string $method, mixed ...$args): mixed
     {
         $ref = new ReflectionMethod($this->controller, $method);

--- a/tests/Unit/Api/FlexApiControllerTranslationTest.php
+++ b/tests/Unit/Api/FlexApiControllerTranslationTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Grav\Plugin\FlexObjects\Tests\Unit\Api;
 
 use Grav\Common\Config\Config;
+use Grav\Common\Data\Blueprint;
 use Grav\Common\Grav;
 use Grav\Common\Language\Language;
+use Grav\Common\User\Interfaces\UserInterface;
+use Grav\Framework\Flex\FlexDirectory;
 use Grav\Plugin\FlexObjects\Api\FlexApiController;
+use Grav\Plugin\FlexObjects\Flex;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -113,9 +117,135 @@ class FlexApiControllerTranslationTest extends TestCase
         self::assertSame([], $this->invoke('normalizeSortConfig', []));
     }
 
+    #[Test]
+    public function detail_actions_are_exposed_as_authorized_per_action_flags(): void
+    {
+        $related = $this->fakeDirectory('payments', [
+            'list' => [
+                'fields' => [],
+                'options' => [],
+            ],
+        ], [
+            'list' => true,
+            'update' => true,
+            'delete' => false,
+        ]);
+
+        $controller = $this->controllerWithRelatedDirectory('payments', $related);
+
+        $detail = $this->invokeOn($controller, 'normalizeDetailConfig', $this->fakeDirectory('user-accounts'), [
+            'enabled' => true,
+            'actions' => true,
+            'relation' => [
+                'type' => 'payments',
+                'local_key' => 'username',
+                'foreign_key' => 'subject_key',
+            ],
+        ], $this->fakeUser(false));
+
+        self::assertIsArray($detail);
+        self::assertTrue($detail['actions']);
+        self::assertTrue($detail['can_edit']);
+        self::assertFalse($detail['can_delete']);
+    }
+
+    #[Test]
+    public function detail_edit_action_is_not_exposed_for_dedicated_admin_next_types(): void
+    {
+        $related = $this->fakeDirectory('user-accounts', [
+            'list' => [
+                'fields' => [],
+                'options' => [],
+            ],
+        ], [
+            'list' => true,
+            'update' => true,
+            'delete' => true,
+        ]);
+
+        $controller = $this->controllerWithRelatedDirectory('user-accounts', $related);
+
+        $detail = $this->invokeOn($controller, 'normalizeDetailConfig', $this->fakeDirectory('payments'), [
+            'enabled' => true,
+            'actions' => true,
+            'relation' => [
+                'type' => 'user-accounts',
+                'local_key' => 'subject_key',
+                'foreign_key' => 'username',
+            ],
+        ], $this->fakeUser(false));
+
+        self::assertIsArray($detail);
+        self::assertTrue($detail['actions']);
+        self::assertFalse($detail['can_edit']);
+        self::assertTrue($detail['can_delete']);
+    }
+
     private function invoke(string $method, mixed ...$args): mixed
     {
-        $ref = new ReflectionMethod($this->controller, $method);
-        return $ref->invoke($this->controller, ...$args);
+        return $this->invokeOn($this->controller, $method, ...$args);
+    }
+
+    private function invokeOn(FlexApiController $controller, string $method, mixed ...$args): mixed
+    {
+        $ref = new ReflectionMethod($controller, $method);
+        return $ref->invoke($controller, ...$args);
+    }
+
+    /**
+     * @param array<string, mixed> $adminConfig
+     * @param array<string, bool> $authorization
+     */
+    private function fakeDirectory(string $type, array $adminConfig = [], array $authorization = []): FlexDirectory
+    {
+        $blueprint = $this->createMock(Blueprint::class);
+        $blueprint->method('fields')->willReturn([]);
+
+        $directory = $this->createMock(FlexDirectory::class);
+        $directory->method('getFlexType')->willReturn($type);
+        $directory->method('getTitle')->willReturn(ucfirst($type));
+        $directory->method('isEnabled')->willReturn(true);
+        $directory->method('getBlueprint')->willReturn($blueprint);
+        $directory->method('getConfig')->willReturnCallback(
+            static function (?string $name = null, mixed $default = null) use ($adminConfig) {
+                return match ($name) {
+                    'admin' => $adminConfig,
+                    'admin.list.fields' => $adminConfig['list']['fields'] ?? [],
+                    'admin.list.options' => $adminConfig['list']['options'] ?? [],
+                    default => $default,
+                };
+            },
+        );
+        $directory->method('isAuthorized')->willReturnCallback(
+            static fn(string $action) => $authorization[$action] ?? false,
+        );
+
+        return $directory;
+    }
+
+    private function fakeUser(bool $super): UserInterface
+    {
+        $user = $this->createMock(UserInterface::class);
+        $user->method('get')->willReturnCallback(
+            static fn($key, mixed $default = null, $separator = null) => $key === 'access.api.super' ? $super : $default,
+        );
+
+        return $user;
+    }
+
+    private function controllerWithRelatedDirectory(string $type, FlexDirectory $directory): FlexApiController
+    {
+        $flex = $this->createMock(Flex::class);
+        $flex->method('getDirectory')->willReturnCallback(
+            static fn(string $requested) => $requested === $type ? $directory : null,
+        );
+
+        $grav = $this->createMock(Grav::class);
+        $grav->method('offsetExists')->willReturn(true);
+        $grav->method('offsetGet')->willReturnCallback(
+            static fn($key) => $key === 'flex_objects' ? $flex : null,
+        );
+
+        return new FlexApiController($grav, new Config([]));
     }
 }


### PR DESCRIPTION
## Context

This is the Flex Objects backend/API half of an Admin Next / Grav 2 reimplementation inspired by https://github.com/trilbymedia/grav-plugin-flex-objects/pull/197.

That earlier PR attempted to bring nested Flex list detail rows into the Grav 1.7/Admin Classic Vue/vuetable UI. Since that UI path is being retired, this PR exposes the backend metadata/filter contract needed by Admin Next instead.

A paired Admin Next PR will add the Svelte UI that consumes this contract.

## What changed

- Adds `GET /api/v1/flex-objects/{type}/metadata` for one directory's Admin Next metadata, including built-in/hidden types like `user-accounts`.
- Normalizes `config.admin.list.detail` into a self-contained contract with `enabled`, labels/icons, relation config, resolved fields, field types/options, limit, actions, and sort.
- Supports exact object filters via `filters[field]=value` for child row queries.
- Normalizes detail sort to the Admin Next shape `{ by, dir }`, while accepting YAML shorthand like `{ timeline_at: desc }`.
- Documents Admin Next nested detail row configuration in the README.
- Adds unit coverage for the detail sort normalization.

## Verification

- `/usr/local/opt/php@8.3/bin/php -l classes/Api/FlexApiController.php`
- `/usr/local/opt/php@8.3/bin/php ../api/vendor/bin/phpunit --configuration phpunit.xml tests/Unit/Api`
  - `7 tests, 15 assertions`
- Live local Admin2 smoke: `user-accounts` metadata returns `relation.sort: { by: "timeline_at", dir: "desc" }`, and payments can be queried with `filters[subject_key]=sogl`.