### PR TITLE
Use admin language for Flex blueprint metadata

### DIFF
--- a/classes/Api/FlexApiController.php
+++ b/classes/Api/FlexApiController.php
@@ -208,6 +208,7 @@ class FlexApiController extends AbstractApiController
     public function blueprints(ServerRequestInterface $request): ResponseInterface
     {
         $this->requirePermission($request, 'api.access');
+        $this->primeAdminLanguages($request);
 
         $flex = $this->getFlex();
         $newToOld = Flex::getLegacyBlueprintMap(false); // [newUrl => oldUrl]
@@ -219,8 +220,8 @@ class FlexApiController extends AbstractApiController
                 'url'         => $url,
                 'legacy_url'  => $newToOld[$url] ?? null,
                 'type'        => $directory->getFlexType(),
-                'title'       => $directory->getTitle(),
-                'description' => $directory->getDescription(),
+                'title'       => $this->translateLabel($directory->getTitle()),
+                'description' => $this->translateLabel($directory->getDescription() ?? ''),
             ];
         }
 

--- a/classes/Api/FlexBlueprintController.php
+++ b/classes/Api/FlexBlueprintController.php
@@ -20,6 +20,7 @@ class FlexBlueprintController extends BlueprintController
     public function flexBlueprint(ServerRequestInterface $request): ResponseInterface
     {
         $this->requirePermission($request, 'api.access');
+        $this->primeAdminLanguages($request);
 
         $type = $this->getRouteParam($request, 'type');
 

--- a/tests/Unit/Api/FlexApiControllerTranslationTest.php
+++ b/tests/Unit/Api/FlexApiControllerTranslationTest.php
@@ -7,10 +7,14 @@ namespace Grav\Plugin\FlexObjects\Tests\Unit\Api;
 use Grav\Common\Config\Config;
 use Grav\Common\Grav;
 use Grav\Common\Language\Language;
+use Grav\Common\User\Interfaces\UserInterface;
+use Grav\Framework\Flex\FlexDirectory;
 use Grav\Plugin\FlexObjects\Api\FlexApiController;
+use Grav\Plugin\FlexObjects\Flex;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -97,9 +101,75 @@ class FlexApiControllerTranslationTest extends TestCase
         );
     }
 
+    #[Test]
+    public function blueprints_endpoint_translates_titles_with_admin_language(): void
+    {
+        $translations = [
+            'ICU.PLUGIN_MYPLUGIN.ADMIN.ITEMS.TITLE' => 'Pagos',
+            'ICU.PLUGIN_MYPLUGIN.ADMIN.ITEMS.DESC'  => 'Historial de pagos',
+        ];
+
+        $language = $this->createMock(Language::class);
+        $language->method('translate')->willReturnCallback(
+            static fn($key, $languages = null, $array = false) => $translations[$key] ?? $key,
+        );
+        $language->method('getLanguage')->willReturn('en');
+
+        $directory = $this->createMock(FlexDirectory::class);
+        $directory->method('getBlueprintFile')->willReturn('blueprints://flex-objects/items.yaml');
+        $directory->method('getFlexType')->willReturn('items');
+        $directory->method('getTitle')->willReturn('PLUGIN_MYPLUGIN.ADMIN.ITEMS.TITLE');
+        $directory->method('getDescription')->willReturn('PLUGIN_MYPLUGIN.ADMIN.ITEMS.DESC');
+
+        $flex = $this->createMock(Flex::class);
+        $flex->method('getBlueprints')->willReturn([$directory]);
+
+        $grav = $this->createMock(Grav::class);
+        $grav->method('offsetExists')->willReturnCallback(
+            static fn($key) => in_array($key, ['language', 'flex_objects', 'locator'], true),
+        );
+        $grav->method('offsetGet')->willReturnCallback(
+            static fn($key) => match ($key) {
+                'language' => $language,
+                'flex_objects' => $flex,
+                'locator' => new FlexTranslationTestLocator(),
+                default => null,
+            },
+        );
+
+        $user = $this->createMock(UserInterface::class);
+        $user->method('get')->willReturnCallback(
+            static fn($key, mixed $default = null) => match ($key) {
+                'access.api.super' => true,
+                'admin_next' => ['preferences' => ['adminLanguage' => 'es']],
+                default => $default,
+            },
+        );
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')->willReturnCallback(
+            static fn($name, $default = null) => $name === 'api_user' ? $user : $default,
+        );
+
+        $controller = new FlexApiController($grav, new Config([]));
+        $response = $controller->blueprints($request);
+        $payload = json_decode((string) $response->getBody(), true);
+
+        self::assertSame('Pagos', $payload['data'][0]['title']);
+        self::assertSame('Historial de pagos', $payload['data'][0]['description']);
+    }
+
     private function invoke(string $method, mixed ...$args): mixed
     {
         $ref = new ReflectionMethod($this->controller, $method);
         return $ref->invoke($this->controller, ...$args);
+    }
+}
+
+final class FlexTranslationTestLocator
+{
+    public function findResource(string $uri, bool $absolute = true, bool $create = false): ?string
+    {
+        return null;
     }
 }


### PR DESCRIPTION
## Context

Admin Next resolves its UI language from the signed-in user's `adminLanguage` preference. The API plugin's blueprint endpoints already call `primeAdminLanguages($request)` before serializing translated labels, so server-side blueprint labels are resolved against that admin language instead of Grav's active site/content language.

Flex Objects has two Flex-specific metadata endpoints that also serialize admin-facing labels:

- `GET /api/v1/flex-objects/blueprints`
- `GET /api/v1/blueprints/flex-objects/{type}`

Those endpoints did not prime the admin language first. As a result, sites whose content language differs from the admin UI language can receive Flex blueprint/form metadata translated in the site language even when Admin Next is set to another language.

## What changed

- Prime the admin language before serializing a Flex directory blueprint.
- Prime the admin language before listing Flex object blueprints.
- Translate the Flex blueprint list `title` and `description` values through `translateLabel()`.
- Add unit coverage for the Flex blueprint list endpoint using a non-English admin language fixture.

## Verification

- `php -l classes/Api/FlexApiController.php`
- `php -l classes/Api/FlexBlueprintController.php`
- `php -l tests/Unit/Api/FlexApiControllerTranslationTest.php`
- `php ../api/vendor/bin/phpunit --configuration phpunit.xml tests/Unit/Api`
  - `7 tests, 14 assertions`