### PR TITLE
Update flex-objects.php

### DIFF
--- a/flex-objects.php
+++ b/flex-objects.php
@@ -13,6 +13,7 @@ use Grav\Common\Utils;
 use Grav\Events\FlexRegisterEvent;
 use Grav\Events\PermissionsRegisterEvent;
 use Grav\Events\PluginsLoadedEvent;
+use Grav\Framework\Acl\Permissions;
 use Grav\Framework\Acl\PermissionsReader;
 use Grav\Framework\Flex\FlexDirectory;
 use Grav\Framework\Flex\FlexForm;
@@ -20,6 +21,7 @@ use Grav\Framework\Flex\Interfaces\FlexAuthorizeInterface;
 use Grav\Framework\Flex\Interfaces\FlexInterface;
 use Grav\Framework\Form\Interfaces\FormInterface;
 use Grav\Framework\Route\Route;
+use Grav\Plugin\Api\PermissionResolver;
 use Grav\Plugin\FlexObjects\Controllers\ObjectController;
 use Grav\Plugin\FlexObjects\FlexFormFactory;
 use Grav\Plugin\Form\Forms;
@@ -989,9 +991,30 @@ class FlexObjectsPlugin extends Plugin
                 continue;
             }
 
-            // Check if user has list permission for this directory
-            if ($user && !$isSuperAdmin && !$directory->isAuthorized('list', 'admin', $user)) {
-                continue;
+            // Check if user has list permission for this directory.
+            // FlexDirectory::isAuthorized() applies a 'test' scope prefix when a
+            // user is explicitly passed, causing the permission lookup to always
+            // fail for non-super-admin users in API context. Use PermissionResolver
+            // (which supports parent-key inheritance) instead.
+            if ($user && !$isSuperAdmin) {
+                $perms = $directory->getConfig('admin.permissions', []);
+                $authorized = false;
+                if ($perms) {
+                    $resolver = new PermissionResolver($this->grav['permissions']);
+                    foreach ($perms as $prefix => $cfg) {
+                        if ($resolver->resolve($user, $prefix . '.list')) {
+                            $authorized = true;
+                            break;
+                        }
+                    }
+                } else {
+                    $resolver = new PermissionResolver($this->grav['permissions']);
+                    $rule = $directory->getAuthorizeRule('admin', 'list');
+                    $authorized = (bool) $resolver->resolve($user, $rule);
+                }
+                if (!$authorized) {
+                    continue;
+                }
             }
 
             // Get object count


### PR DESCRIPTION
Part of changes to make a Flex Object visible and editable in Admin2 without giving access to any other Admin functions (e.g,. Configuration, Pages, Users, Media etc.).

## Files Changed

1. user/plugins/flex-objects/classes/Api/FlexApiController.php
- Added use Grav\Common\User\Interfaces\UserInterface; import
- Added isDirectoryAuthorized() private helper using hasPermission() (PermissionResolver with parent-key inheritance) instead of $directory->isAuthorized()
- Replaced $directory->isAuthorized() calls in directories(), metadata(), and normalizeDetailConfig()

2. user/plugins/flex-objects/flex-objects.php
- Added use Grav\Framework\Acl\Permissions; and use Grav\Plugin\Api\PermissionResolver; imports
- Replaced $directory->isAuthorized('list', 'admin', $user) in onApiSidebarItems() with PermissionResolver-based check

3. user/blueprints/flex-objects/<flex-directory-name>.yaml
- Added admin.permissions section defining admin.<flex-directory-name> (crudl) and api.<flex-directory-name> (crudl) permission namespaces

4. user/accounts/<flex-directory-name>.yaml
- Set admin.<flex-directory-name>: true and api.<flex-directory-name>: true (PermissionResolver inherits down to all sub-actions)