### PR TITLE
Enforce API-key scope cap and restore embedded flex-form page auth gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.4.5
+## 07/07/2026
+
+1. [](#bugfix)
+    * [security] Scoped API keys are now capped on every Flex object, media, and export endpoint, so a narrowly-scoped key can no longer reach Flex directories outside its scope (GHSA-x7hm).
+    * [security] Restored the page-level access check for embedded Flex edit forms, so an unauthorized visitor can no longer open a pre-filled edit form through a page's own route.
+
 # v1.4.4
 ## 07/03/2026
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -2,7 +2,7 @@ name: Flex Objects
 slug: flex-objects
 type: plugin
 testing: false
-version: 1.4.4
+version: 1.4.5
 description: Flex Objects plugin allows you to manage Flex Objects in Grav Admin.
 icon: list-alt
 author:

--- a/classes/Api/FlexApiController.php
+++ b/classes/Api/FlexApiController.php
@@ -661,6 +661,16 @@ class FlexApiController extends AbstractApiController
     ): void {
         $user = $this->getUser($request);
 
+        // API-key scope cap (GHSA-x7hm). A key minted with a non-empty `scopes`
+        // list is capped to exactly those permissions regardless of the owning
+        // account's ACL. AbstractApiController::requirePermission() enforces this
+        // before its own super-admin short-circuit, but the Flex CRUD/media/export
+        // routes authorize against the directory blueprint instead of calling
+        // requirePermission(), so the cap must be applied here too — before the
+        // super-admin bypass below — or a narrowly-scoped key on a super account
+        // would reach every Flex directory.
+        $this->requireFlexScope($request, $directory, $action);
+
         if ($this->isSuperAdmin($user)) {
             return;
         }
@@ -695,6 +705,69 @@ class FlexApiController extends AbstractApiController
         // None matched — report the first prefix for a clear error
         $prefix = array_key_first($permissions);
         throw new \Grav\Plugin\Api\Exceptions\ForbiddenException("Missing required permission: {$prefix}.{$action}");
+    }
+
+    /**
+     * Enforce the API-key scope cap for a Flex directory action (GHSA-x7hm).
+     *
+     * When the request carries a non-empty `api_key_scopes` attribute, the key
+     * is restricted to those scopes even on a super-admin account. The action is
+     * allowed only if a scope permits at least one of the directory's candidate
+     * permissions (`<prefix>.<action>` for each blueprint permission prefix, plus
+     * the generic `admin.flex-object.<action>` fallback used when a directory
+     * declares no permissions block). An empty or absent scope set (unscoped
+     * keys, JWT, and session credentials) means full access, so this is a no-op.
+     *
+     * The scope-match logic mirrors AbstractApiController::scopesPermit(), which
+     * is private in the API plugin; kept in sync deliberately.
+     */
+    private function requireFlexScope(
+        ServerRequestInterface $request,
+        FlexDirectory $directory,
+        string $action,
+    ): void {
+        $scopes = $request->getAttribute('api_key_scopes');
+        if (!is_array($scopes) || $scopes === []) {
+            return;
+        }
+
+        $candidates = [];
+        foreach (($directory->getConfig('admin.permissions') ?? []) as $prefix => $config) {
+            $candidates[] = $prefix . '.' . $action;
+        }
+        $candidates[] = 'admin.flex-object.' . $action;
+
+        foreach ($candidates as $permission) {
+            if ($this->scopesPermitPermission($scopes, $permission)) {
+                return;
+            }
+        }
+
+        throw new \Grav\Plugin\Api\Exceptions\ForbiddenException(
+            "API key is not authorized for the '{$action}' action on '{$directory->getFlexType()}'.",
+        );
+    }
+
+    /**
+     * Whether a non-empty API-key scope list grants a permission. A scope grants
+     * its own permission and everything beneath it (`api.contacts` covers
+     * `api.contacts.read`); `*` grants everything. Mirrors
+     * AbstractApiController::scopesPermit() (see GHSA-x7hm).
+     *
+     * @param array<int, mixed> $scopes
+     */
+    private function scopesPermitPermission(array $scopes, string $permission): bool
+    {
+        foreach ($scopes as $scope) {
+            if (!is_string($scope) || $scope === '') {
+                continue;
+            }
+            if ($scope === '*' || $scope === $permission || str_starts_with($permission, $scope . '.')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function serializeObject(FlexObjectInterface $object): array

--- a/flex-objects.php
+++ b/flex-objects.php
@@ -449,7 +449,7 @@ class FlexObjectsPlugin extends Plugin
         // Update dynamic flex forms from the page.
         $form = null;
         foreach ($forms as $name => $test) {
-            $type = $form['type'] ?? null;
+            $type = $test['type'] ?? null;
             if ($type === 'flex') {
                 $form = $test;
 


### PR DESCRIPTION
Two authorization fixes for the Admin Next / REST API path, bundled for a coordinated 1.4.5 release. Both are security-sensitive, so this is one PR rather than two so it can ship as a single advisory. Happy to split if you'd rather.

## 1. API-key scope cap on Flex endpoints (GHSA-x7hm)

`AbstractApiController::requirePermission()` caps a scoped API key to its `scopes` list *before* the super-admin short-circuit, so a key minted on a super-admin account but scoped to one narrow permission stays capped. But the Flex object/media/export routes don't call `requirePermission()` — they authorize against the directory blueprint through the private `requireFlexPermission()`, which never read the `api_key_scopes` request attribute. Result: a scoped key could reach **every** Flex directory (list/read/create/update/delete, media upload/delete, full YAML export), fully bypassing the cap.

`requireFlexPermission()` now applies the same scope cap first, against the directory's candidate permissions (`<prefix>.<action>` per blueprint permission prefix, plus the `admin.flex-object.<action>` fallback). The scope-match logic mirrors the API plugin's private `scopesPermit()`. It is a **no-op** for unscoped keys, JWT, and session credentials, so there is no behavior change for the common case.

> Follow-up option: promote `AbstractApiController::scopesPermit()` to `protected` in grav-plugin-api so consumers can reuse it instead of the mirrored helper here.

## 2. Embedded flex-form page authorization gate

`authorizePage()` looped over the page's forms with `\$type = \$form['type']`, but `\$form` is initialized to `null` and only assigned *inside* the `type === 'flex'` branch, so the condition was never true. The whole page-level access block was skipped for pages that host a flex form without a `flex:` header. An unauthorized visitor hitting `/some-edit-page/id:<key>` would get the edit form **pre-filled with the object's stored data** (only the final submit stayed blocked). This gate has been dead since v1.2.0. One-character fix: read `\$test` (the loop variable).

## Testing
- `php -l` clean on both files.
- Unit suite: the 8 passing tests still pass; the 2 pre-existing errors (`PermissionResolver` given `null` permissions in the test harness) fail identically on `develop` and are unrelated.
- Scope-cap behavior traced against `AbstractApiController::requirePermission()` / `scopesPermit()`.

Manifest bumped to 1.4.5 and CHANGELOG updated.