### PR TITLE
Add translation keys for security section and restrict page frontmatter

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -46,13 +46,13 @@ form:
         type: bool
     security_section:
       type: section
-      title: Security
+      title: PLUGIN_FLEX_OBJECTS.SECURITY_SECTION
       underline: true
 
     security.restrict_page_frontmatter:
       type: toggle
-      label: Restrict Page Frontmatter Editing
-      help: When enabled, non-superusers cannot modify form, forms, process, or twig settings in page headers. Disable if editors need to modify forms.
+      label: PLUGIN_FLEX_OBJECTS.SECURITY.RESTRICT_PAGE_FRONTMATTER
+      help: PLUGIN_FLEX_OBJECTS.SECURITY.RESTRICT_PAGE_FRONTMATTER_HELP
       highlight: 1
       default: 1
       options:

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -9,6 +9,10 @@ PLUGIN_FLEX_OBJECTS:
   EMPTY_RESULT: The requested query returns no result
 
   USE_BUILT_IN_CSS: "Use built in CSS"
+  SECURITY_SECTION: "Security"
+  SECURITY:
+    RESTRICT_PAGE_FRONTMATTER: "Restrict Page Frontmatter Editing"
+    RESTRICT_PAGE_FRONTMATTER_HELP: "When enabled, non-superusers cannot modify form, forms, process, or twig settings in page headers. Disable if editors need to modify forms."
   EXTRA_ADMIN_TWIG_PATH: "Extra Admin Twig Path"
   DIRECTORIES: "Directories"
   CSV: "CSV"

--- a/languages/es.yaml
+++ b/languages/es.yaml
@@ -9,6 +9,10 @@ PLUGIN_FLEX_OBJECTS:
   EMPTY_RESULT: The requested query returns no result
 
   USE_BUILT_IN_CSS: "Usar CSS incorporado"
+  SECURITY_SECTION: "Seguridad"
+  SECURITY:
+    RESTRICT_PAGE_FRONTMATTER: "Restringir edición de Frontmatter de página"
+    RESTRICT_PAGE_FRONTMATTER_HELP: "Cuando está activada, los usuarios que no sean superusuarios no pueden modificar la configuración de `form`, `forms`, `process` ni `twig` en las cabeceras de las páginas. Desactívala si los editores necesitan modificar los formularios."
   EXTRA_ADMIN_TWIG_PATH: "Ruta extra de twig para Admin"
   DIRECTORIES: "Directorios"
   CSV: "CSV"


### PR DESCRIPTION
- Add SECURITY_SECTION translation key to blueprints and language files
- Add SECURITY.RESTRICT_PAGE_FRONTMATTER and help text translation keys
- Translations added for both en.yaml and es.yaml
- Update blueprints.yaml to use translation keys instead of hardcoded text